### PR TITLE
Fix image.chmod()

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -46,7 +46,7 @@ Image.prototype.chgrp = function(group, callback) {
 };
 
 Image.prototype.chmod = function(user_use, user_manage, user_admin, group_use, group_manage, group_admin, other_use, other_manage, other_admin, callback) {
-  this.modem.call('image.chmod', [this.id, user_use, user_manage, user_admin, group_use, group_manage, group_admin, other_use, other_manage, other_admin, callback], function(err, data) {
+  this.modem.call('image.chmod', [this.id, user_use, user_manage, user_admin, group_use, group_manage, group_admin, other_use, other_manage, other_admin], function(err, data) {
     if (err) return callback(err);
     callback(null, data);
   });


### PR DESCRIPTION
This typo leads to
```
Error: XML-RPC fault: Parameter that is supposed to be boolean is not
```